### PR TITLE
创建橙子建站落地页时微信小程序组件差一个参数，style_type为WITHOUT_DESC_BUTTON样式2时，传入按钮的背景图片需要…

### DIFF
--- a/models/model_tools_site_create_v2_request_bricks_inner_setting.go
+++ b/models/model_tools_site_create_v2_request_bricks_inner_setting.go
@@ -12,9 +12,10 @@ package models
 
 // ToolsSiteCreateV2RequestBricksInnerSetting
 type ToolsSiteCreateV2RequestBricksInnerSetting struct {
-	Avatar     *ToolsSiteCreateV2RequestBricksInnerSettingAvatar     `json:"avatar,omitempty"`
-	Background *ToolsSiteCreateV2RequestBricksInnerSettingBackground `json:"background,omitempty"`
-	Button     *ToolsSiteCreateV2RequestBricksInnerSettingButton     `json:"button,omitempty"`
+	Avatar     *ToolsSiteCreateV2RequestBricksInnerSettingAvatar          `json:"avatar,omitempty"`
+	Background *ToolsSiteCreateV2RequestBricksInnerSettingBackground      `json:"background,omitempty"`
+	Image      *ToolsSiteCreateV2RequestBricksInnerSettingBackgroundImage `json:"image,omitempty"`
+	Button     *ToolsSiteCreateV2RequestBricksInnerSettingButton          `json:"button,omitempty"`
 	//
 	IntroduceType *string `json:"introduce_type,omitempty"`
 	//


### PR DESCRIPTION
创建橙子建站落地页时微信小程序组件差一个参数，style_type为WITHOUT_DESC_BUTTON样式2时，传入按钮的背景图片需要，文档中有这个参数，sdk中漏掉了，现补上了，紧急需要调用，请尽快合并加上